### PR TITLE
Add React TypeScript hierarchy manager

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hierarchy Manager</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "annu-frontend-assignment",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.1.0",
+    "vite": "^5.0.0",
+    "vitest": "^0.34.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import CreateHierarchy from './components/CreateHierarchy';
+import AddNode from './components/AddNode';
+import StoreList from './components/StoreList';
+import { HierarchyService } from './services/hierarchyService';
+
+const service = new HierarchyService();
+
+const App: React.FC = () => {
+  const [hierarchyId, setHierarchyId] = React.useState<string | null>(null);
+  const [rootId, setRootId] = React.useState<string | null>(null);
+
+  const handleCreate = () => {
+    const hid = service.createHierarchy();
+    const rid = service.getRootId(hid);
+    setHierarchyId(hid);
+    setRootId(rid);
+  };
+
+  return (
+    <div>
+      <h1>Hierarchy Manager</h1>
+      <CreateHierarchy onCreate={handleCreate} hierarchyId={hierarchyId} rootId={rootId} />
+      {hierarchyId && (
+        <>
+          <AddNode hierarchyId={hierarchyId} service={service} />
+          <StoreList hierarchyId={hierarchyId} service={service} />
+        </>
+      )}
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/AddNode.tsx
+++ b/src/components/AddNode.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { HierarchyService, NodeType } from '../services/hierarchyService';
+
+interface Props {
+  hierarchyId: string;
+  service: HierarchyService;
+}
+
+const AddNode: React.FC<Props> = ({ hierarchyId, service }) => {
+  const [parentId, setParentId] = useState('');
+  const [type, setType] = useState<NodeType>('franchise');
+  const [name, setName] = useState('');
+  const [number, setNumber] = useState('');
+  const [address, setAddress] = useState('');
+  const [createdId, setCreatedId] = useState<string | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const nodeId = service.addNode(hierarchyId, parentId, {
+        type,
+        name,
+        number,
+        address: type === 'store' ? address : undefined,
+      });
+      setCreatedId(nodeId);
+    } catch (err) {
+      alert((err as Error).message);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Add Node</h2>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label>Parent ID:</label>
+          <input value={parentId} onChange={e => setParentId(e.target.value)} />
+        </div>
+        <div>
+          <label>Type:</label>
+          <select value={type} onChange={e => setType(e.target.value as NodeType)}>
+            <option value="franchise">Franchise</option>
+            <option value="region">Region</option>
+            <option value="store">Store</option>
+          </select>
+        </div>
+        <div>
+          <label>Name:</label>
+          <input value={name} onChange={e => setName(e.target.value)} />
+        </div>
+        <div>
+          <label>Number:</label>
+          <input value={number} onChange={e => setNumber(e.target.value)} />
+        </div>
+        {type === 'store' && (
+          <div>
+            <label>Address:</label>
+            <input value={address} onChange={e => setAddress(e.target.value)} />
+          </div>
+        )}
+        <button type="submit">Add</button>
+      </form>
+      {createdId && <p>Created node {createdId}</p>}
+    </div>
+  );
+};
+
+export default AddNode;

--- a/src/components/CreateHierarchy.tsx
+++ b/src/components/CreateHierarchy.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface Props {
+  onCreate: () => void;
+  hierarchyId: string | null;
+  rootId: string | null;
+}
+
+const CreateHierarchy: React.FC<Props> = ({ onCreate, hierarchyId, rootId }) => {
+  return (
+    <div>
+      <button onClick={onCreate}>Create New Hierarchy</button>
+      {hierarchyId && (
+        <p>
+          Created hierarchy {hierarchyId} with root node {rootId}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default CreateHierarchy;

--- a/src/components/StoreList.tsx
+++ b/src/components/StoreList.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { HierarchyService, StoreNode } from '../services/hierarchyService';
+
+interface Props {
+  hierarchyId: string;
+  service: HierarchyService;
+}
+
+const StoreList: React.FC<Props> = ({ hierarchyId, service }) => {
+  const [nodeId, setNodeId] = useState('');
+  const [stores, setStores] = useState<StoreNode[]>([]);
+
+  const handleList = () => {
+    try {
+      const result = service.listStores(hierarchyId, nodeId);
+      setStores(result);
+    } catch (err) {
+      alert((err as Error).message);
+    }
+  };
+
+  return (
+    <div>
+      <h2>List Stores</h2>
+      <div>
+        <label>Node ID:</label>
+        <input value={nodeId} onChange={e => setNodeId(e.target.value)} />
+        <button onClick={handleList}>List</button>
+      </div>
+      <ul>
+        {stores.map(store => (
+          <li key={store.id}>
+            {store.name} ({store.number}) - {store.address}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default StoreList;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/services/hierarchyService.test.ts
+++ b/src/services/hierarchyService.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { HierarchyService } from './hierarchyService';
+
+describe('HierarchyService', () => {
+  it('creates hierarchy and returns stores', () => {
+    const service = new HierarchyService();
+    const hid = service.createHierarchy();
+    const root = service.getRootId(hid);
+    const fid = service.addNode(hid, root, {
+      type: 'franchise',
+      name: 'Joe\'s Franchise',
+      number: '001',
+    });
+    const rid = service.addNode(hid, fid, {
+      type: 'region',
+      name: 'North',
+      number: '01',
+    });
+    const sid = service.addNode(hid, rid, {
+      type: 'store',
+      name: 'Store A',
+      number: '0001',
+      address: '123 Main St',
+    });
+    const stores = service.listStores(hid, fid);
+    expect(stores.map(s => s.id)).toContain(sid);
+  });
+});

--- a/src/services/hierarchyService.ts
+++ b/src/services/hierarchyService.ts
@@ -1,0 +1,105 @@
+export type NodeType = 'jack' | 'franchise' | 'region' | 'store';
+
+export interface BaseNode {
+  id: string;
+  type: NodeType;
+  name: string;
+  number: string;
+  parentId?: string;
+  children: string[];
+}
+
+export interface StoreNode extends BaseNode {
+  type: 'store';
+  address: string;
+}
+
+export type HierarchyNode = BaseNode | StoreNode;
+
+interface Hierarchy {
+  nodes: Map<string, HierarchyNode>;
+  rootId: string;
+}
+
+export class HierarchyService {
+  private hierarchies: Map<string, Hierarchy> = new Map();
+  private hierarchyCounter = 1;
+  private nodeCounter = 1;
+
+  createHierarchy(): string {
+    const hierarchyId = `h-${this.hierarchyCounter++}`;
+    const rootId = `n-${this.nodeCounter++}`;
+    const rootNode: HierarchyNode = {
+      id: rootId,
+      type: 'jack',
+      name: 'Jack in the Box',
+      number: '0',
+      children: [],
+    };
+    const hierarchy: Hierarchy = {
+      nodes: new Map([[rootId, rootNode]]),
+      rootId,
+    };
+    this.hierarchies.set(hierarchyId, hierarchy);
+    return hierarchyId;
+  }
+
+  getRootId(hierarchyId: string): string {
+    const hierarchy = this.hierarchies.get(hierarchyId);
+    if (!hierarchy) throw new Error('Hierarchy not found');
+    return hierarchy.rootId;
+  }
+
+  addNode(
+    hierarchyId: string,
+    parentId: string,
+    data: {
+      type: NodeType;
+      name: string;
+      number: string;
+      address?: string;
+    }
+  ): string {
+    const hierarchy = this.hierarchies.get(hierarchyId);
+    if (!hierarchy) throw new Error('Hierarchy not found');
+    const parent = hierarchy.nodes.get(parentId);
+    if (!parent) throw new Error('Parent node not found');
+
+    const id = `n-${this.nodeCounter++}`;
+    let newNode: HierarchyNode = {
+      id,
+      type: data.type,
+      name: data.name,
+      number: data.number,
+      parentId,
+      children: [],
+    };
+    if (data.type === 'store') {
+      if (!data.address) throw new Error('Store requires an address');
+      newNode = { ...newNode, type: 'store', address: data.address };
+    }
+
+    hierarchy.nodes.set(id, newNode);
+    parent.children.push(id);
+    return id;
+  }
+
+  listStores(hierarchyId: string, nodeId: string): StoreNode[] {
+    const hierarchy = this.hierarchies.get(hierarchyId);
+    if (!hierarchy) throw new Error('Hierarchy not found');
+    const start = hierarchy.nodes.get(nodeId);
+    if (!start) throw new Error('Node not found');
+
+    const result: StoreNode[] = [];
+    const visit = (id: string) => {
+      const node = hierarchy.nodes.get(id);
+      if (!node) return;
+      if (node.type === 'store') {
+        result.push(node as StoreNode);
+      }
+      node.children.forEach(visit);
+    };
+    visit(nodeId);
+    return result;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2019"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});


### PR DESCRIPTION
## Summary
- scaffold React + Vite TypeScript project
- implement in-memory hierarchy service with create, add, and list stores
- add UI components to manage hierarchy nodes

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f633b2a588332b030c7e7127fb0c4