### PR TITLE
feat: add express backend server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.env
+server/dist
+dist
+package-lock.json
+

--- a/README.md
+++ b/README.md
@@ -38,3 +38,17 @@ Think though, about how you would persist your hierarchy, particularly given the
  
 
 Please return a solution that aligns with what you think are appropriate choices for production-quality software. Be prepared to discuss your solution, as well as appropriate production considerations.
+
+## Backend
+
+A simple Express server in `server/index.ts` provides REST endpoints backed by an in-memory hierarchy:
+
+- `POST /hierarchies` creates a new hierarchy and returns its id.
+- `POST /hierarchies/:hid/nodes` adds a node under the provided parent.
+- `GET /hierarchies/:hid/nodes/:id/stores` lists stores under a node.
+
+Run the server with:
+
+```bash
+npm run server
+```

--- a/package.json
+++ b/package.json
@@ -6,16 +6,22 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "server": "ts-node server/index.ts",
+    "build:server": "tsc -p server/tsconfig.json"
   },
   "dependencies": {
+    "express": "^4.18.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@types/express": "^4.17.17",
+    "@types/node": "^18.17.0",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.0.0",
+    "ts-node": "^10.9.1",
     "typescript": "^5.1.0",
     "vite": "^5.0.0",
     "vitest": "^0.34.0"

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,40 @@
+import express, { Request, Response } from 'express';
+import { HierarchyService } from '../src/services/hierarchyService';
+
+const app = express();
+app.use(express.json());
+
+const service = new HierarchyService();
+
+app.post('/hierarchies', (req: Request, res: Response) => {
+  const id = service.createHierarchy();
+  res.status(201).json({ hierarchyId: id });
+});
+
+app.post('/hierarchies/:hid/nodes', (req: Request, res: Response) => {
+  const { hid } = req.params;
+  const { parentId, type, name, number, address } = req.body;
+  try {
+    const nodeId = service.addNode(hid, parentId, { type, name, number, address });
+    res.status(201).json({ nodeId });
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+app.get('/hierarchies/:hid/nodes/:id/stores', (req: Request, res: Response) => {
+  const { hid, id } = req.params;
+  try {
+    const stores = service.listStores(hid, id);
+    res.json({ stores });
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+
+export default app;

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["index.ts"]
+}


### PR DESCRIPTION
## Summary
- add Express REST server for in-memory hierarchy management
- document backend usage and endpoints

## Testing
- `npm test`
- `npx tsc -p server/tsconfig.json --noEmit` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_688f7c42e3548332867e6995432bd31f